### PR TITLE
 Resize and move github logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
         <p id="options">
             <a href="about.html">About</a>
         </p>
+        <img src="https://github.githubassets.com/images/modules/logos_page/Octocat.png" id="octocat"> 
         <h1><a href="#">Collaborating with Git</a></h1>
         <ul id="menu">
             <li><a href="#">Home</a></li>
@@ -58,7 +59,7 @@
                 <div class="clear"></div>
             </div>
         </div>
-<img src="https://github.githubassets.com/images/modules/logos_page/Octocat.png"> 
+
 </body>
 
 </html>

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -45,6 +45,7 @@ input {
     padding: 0
 }
 
+
 a img,
 :link img,
 :visited img {
@@ -105,6 +106,12 @@ h1 a:hover {
 .wrap {
     margin: 25px auto;
     width: 880px;
+}
+
+#octocat { 
+    width: 50px;
+    float: right;
+   
 }
 
 #options {


### PR DESCRIPTION
Per recommendation, resized GitHub logo to 50px and moved up in the header. 
Responsiveness  for mobiles not added in yet as when you collapse the browser it cuts off some area in the header. 